### PR TITLE
fix: explicitly check for true before running goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created == "true" }}
     steps:
       # Checkout code (full history)
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: Matthias Riegler <matthias.riegler@ankorstore.com>
